### PR TITLE
track vux problem

### DIFF
--- a/app/web/page/admin/home/home.vue
+++ b/app/web/page/admin/home/home.vue
@@ -7,16 +7,13 @@
 </template>
 <script type="text/babel">
 import Vue from 'vue';
-import ElementUI from 'element-ui';
 import VueI18n from 'vue-i18n';
-import 'element-ui/lib/theme-chalk/index.css';
 import createI18n from 'framework/i18n/admin';
 import store from './store/app';
 import router from './router';
 import AdminLayout from 'component/layout/admin';
 
 Vue.use(VueI18n);
-Vue.use(ElementUI);
 
 export default {
   router,

--- a/app/web/page/admin/login/login.vue
+++ b/app/web/page/admin/login/login.vue
@@ -46,7 +46,7 @@ import {
   Input,
   Button,
   Checkbox
-} from 'element-ui';
+} from 'vux';
 Vue.component(Input.name, Input);
 Vue.component(Button.name, Button);
 Vue.component(Checkbox.name, Checkbox);

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "egg-scripts": "^2.5.1",
     "egg-validate": "^1.0.0",
     "egg-view-vue-ssr": "^3.0.5",
-    "element-ui": "^2.0.8",
     "extend": "~3.0.0",
     "font-awesome": "^4.7.0",
+    "less": "^2.7.3",
+    "less-loader": "^4.1.0",
     "lodash": "^4.17.4",
     "lodash-id": "^0.14.0",
     "lowdb": "^1.0.0",
@@ -39,7 +40,10 @@
     "vue-material-input": "^1.2.0",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1",
-    "vuex-router-sync": "^5.0.0"
+    "vuex-router-sync": "^5.0.0",
+    "vux": "^2.9.2",
+    "vux-loader": "^1.2.9",
+    "yaml-loader": "^0.5.0"
   },
   "devDependencies": {
     "autod-egg": "^1.0.0",
@@ -51,7 +55,8 @@
     "eslint": "^4.19.1",
     "eslint-config-egg": "^5.0.0",
     "eslint-plugin-vue": "^4.4.0",
-    "ip": "^1.1.5"
+    "ip": "^1.1.5",
+    "vue-loader": "14.2.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,11 @@
-'use strict';
-// 零配置简化, 详情：https://www.yuque.com/easy-team/easywebpack/v4
-module.exports = {
-  node: {
-    console: true
-  }
-};
+// target: web 表示只获取前端构建 Webpack 配置
+// refer: https://www.yuque.com/easy-team/easywebpack/native
+const easywebpack = require('easywebpack-vue');
+const vuxLoader = require('vux-loader');
+const baseWebpackConfig = easywebpack.getWebpackConfig({
+  target: 'vue', // target: web 表示只获取前端构建 Webpack 配置
+});
+// 拿到基础配置, 可以进行二次加工
+module.exports = vuxLoader.merge(baseWebpackConfig, {
+  plugins: ['vux-ui']
+});


### PR DESCRIPTION
follow https://github.com/easy-team/egg-vue-webpack-boilerplate/issues/40

按照vux中的issue：vue-loader版本锁定在 14.2.2, less版本在2.7.3

目前报错为：
https://github.com/airyland/vux/issues/3108