### PR TITLE
fix: root component's style not be injected by renderer

### DIFF
--- a/app/web/framework/vue/entry/server.js
+++ b/app/web/framework/vue/entry/server.js
@@ -25,8 +25,13 @@ export default function render(options) {
     };
   }
   return context => {
-    const VueApp = Vue.extend(options);
-    const app = new VueApp({ data: context.state });
+    const data = Object.assign({}, context.state, options.data && options.data())
+    options.data = function () {
+      return data
+    };
+    const app = new Vue({
+      render: (h) => h(options)
+    });
     return new Promise(resolve => {
       resolve(app);
     });


### PR DESCRIPTION
在开发环境下， 根实例的`style`标签没有被`vue renderer`内联进去。它的`style`是通过客户端的`style-loader`获取的。这样就会出现页面闪动的情况。
解决办法就是不把入口组件作为根实例，而是让其作为一个子组件, 这样每个页面的根组件样式就会被`context.renderStyles()`内联进去。
```js
  const app = new Vue({
     render: (h) => h(page)
})
```
这样客户端每个.vue组件的样式就不需要交给`style-loader`处理了，交给`vue-style-loader`处理就可以了，不然会造成重复样式，因为在`server render`过程中样式就都已经被内联进去了。可以在`easywebpack-vue`的`client.js`文件里新增`vue-style-loader`,覆盖`style-loader`
```js
class WebpackServerBuilder extends WebpackBaseBuilder(EasyWebpack.WebpackServerBuilder) {
  constructor(config) {
    // ...
    this.setStyleLoader('vue-style-loader');
  }
}
```
